### PR TITLE
Allow v3 for catalog API, which is backwards compatible

### DIFF
--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -182,7 +182,12 @@ BigCommerce.prototype.request = function(type, path, data, cb) {
   var request = this.createAPIRequest();
   var fullPath = '/stores/' +
     this.config.storeHash +
-    '/' + version + path.replace(/(\?|$)/, extension + '$1');
+    '/' + version;
+  if (version !== 'v3') {
+    fullPath += path.replace(/(\?|$)/, extension + '$1');
+  } else {
+    fullPath += path;
+  }
 
   return request.completeRequest(type, fullPath, data, cb);
 };

--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -164,6 +164,7 @@ BigCommerce.prototype.request = function(type, path, data, cb) {
   }
 
   var extension = '';
+  var version = 'v2';
 
   switch (this.config.responseType) {
     case 'xml':
@@ -174,10 +175,14 @@ BigCommerce.prototype.request = function(type, path, data, cb) {
       break;
   }
 
+  if (path.indexOf('/catalog') === 0) {
+    version = 'v3';
+  }
+
   var request = this.createAPIRequest();
   var fullPath = '/stores/' +
     this.config.storeHash +
-    '/v2' + path.replace(/(\?|$)/, extension + '$1');
+    '/' + version + path.replace(/(\?|$)/, extension + '$1');
 
   return request.completeRequest(type, fullPath, data, cb);
 };

--- a/test/bigcommerce.js
+++ b/test/bigcommerce.js
@@ -293,6 +293,22 @@ describe('BigCommerce', function() {
         done();
       });
     });
+
+    it('should use v3 for catalog requests', function(done) {
+      var requestStub = sandbox.stub(
+        Request.prototype,
+        'completeRequest',
+        function(method, path, data, cb) {
+          path.should.equal('/stores/12abc/v3/catalog');
+          cb(null, {}, { text: '' });
+        }
+      );
+
+      bc.request('get', '/catalog', null, function() {
+        requestStub.restore();
+        done();
+      });
+    });
   });
 
   describe('#get', function() {


### PR DESCRIPTION
Use v3 for catalog API, which is backwards compatible, but adds new features.