### PR TITLE
Status code errors become warnings

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -97,20 +97,18 @@ Request.prototype.completeRequest = function(method, path, data, cb) {
     });
 
     res.on('end', function() {
-
       logger.info('Request complete');
 
       if (res.statusCode >= 400 && res.statusCode <= 600) {
-        var error = new Error('Request failed with code: ' +
+        var error = new Error('Request returned error code: ' +
           res.statusCode + ' and body: ' + body);
         error.code = res.statusCode;
-        logger.error(error.message);
+        logger.info(error.message);
         if (cb) cb(error, null, res);
         return deferred.reject(error);
       }
 
       try {
-
         var pattern = new RegExp('application/json');
         if (!pattern.test(res.headers['content-type'])) {
           if (cb) cb(null, body, res);
@@ -139,9 +137,7 @@ Request.prototype.completeRequest = function(method, path, data, cb) {
         if (cb) cb(e, null, res);
         return deferred.reject(e);
       }
-
     });
-
   });
 
   if (data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-bigcommerce",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A node module for authentication and use with the BigCommerce API",
   "main": "./lib/bigcommerce",
   "scripts": {


### PR DESCRIPTION
400 and 500 status codes aren't "errors", they can be perfectly valid responses. A client checking if a product exists in a store with a GET doesn't want an error logged when it doesn't.