### PR TITLE
Don't return an unresolved promise when using callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# Sublime project files
+node-bigcommerce.sublime-*

--- a/lib/request.js
+++ b/lib/request.js
@@ -84,7 +84,7 @@ Request.prototype.completeRequest = function(method, path, data, cb) {
 
         err.retryAfter = Number(timeToWait);
 
-        if (cb) cb(err);
+        if (cb) return deferred.resolve(cb(err));
         return deferred.reject(err);
       }
 


### PR DESCRIPTION
If client's expecting callback use, they won't catch the rejected promise.