### PR TITLE
Add support for specifying an API version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
 - '4'
-- '5'
 - '6'
-- '7'
+- '8'
 deploy:
   provider: npm
   email: stefano+npm@sala.io

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ var bigCommerce = new BigCommerce({
   clientId: '128ecf542a35ac5270a87dc740918404',
   secret: 'acbd18db4cc2f85cedef654fccc4a4d8',
   callback: 'https://myapplication.com/auth',
-  responseType: 'json'
+  responseType: 'json',
+  apiVersion: 'v3' // Default is v2
 });
 ```
 

--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -39,6 +39,7 @@ var BigCommerce = function(cfg) {
   this.config.logLevel = this.config.logLevel ?
     levels[this.config.logLevel] : 0;
   logger.level = this.config.logLevel;
+  this.apiVersion = this.config.apiVersion || 'v2';
 };
 
 BigCommerce.prototype.verify = function(signedRequest) {
@@ -167,9 +168,11 @@ BigCommerce.prototype.request = function(type, path, data, cb) {
   }
 
   var extension = this.config.responseType === 'xml' ? '.xml' : '';
-  var version = 'v2';
+  var version = this.apiVersion;
 
   if (path.indexOf('/catalog') === 0) {
+    // This is legacy behavior and will be removed in the next major version of
+    // node-bigcommerce.
     version = 'v3';
   }
 

--- a/test/bigcommerce.js
+++ b/test/bigcommerce.js
@@ -33,11 +33,17 @@ describe('BigCommerce', function() {
     });
 
     it('should save config to the object', function() {
-      new BigCommerce({ test: true }).config.should.not.be.null;
+      var newBc = new BigCommerce({ test: true });
+      newBc.config.should.not.be.null;
+      newBc.apiVersion.should.equal('v2');
     });
 
     it('should set the logger to the correct level', function() {
       new BigCommerce({ logLevel: 'info' }).logger.level.should.equal(1);
+    });
+
+    it('should set api version to a default', function() {
+      new BigCommerce({ apiVersion: 'v3' }).apiVersion.should.equal('v3');
     });
   });
 
@@ -294,7 +300,7 @@ describe('BigCommerce', function() {
       });
     });
 
-    it('should use v3 for catalog requests', function(done) {
+    it('should use v3 for catalog requests (LEGACY)', function(done) {
       var requestStub = sandbox.stub(
         Request.prototype,
         'completeRequest',
@@ -305,6 +311,31 @@ describe('BigCommerce', function() {
       );
 
       bc.request('get', '/catalog', null, function() {
+        requestStub.restore();
+        done();
+      });
+    });
+
+    it('should use v3 if specified in config', function(done) {
+      var requestStub = sandbox.stub(
+        Request.prototype,
+        'completeRequest',
+        function(method, path, data, cb) {
+          path.should.equal('/stores/12abc/v3/themes');
+          cb(null, {}, { text: '' });
+        }
+      );
+
+      var bcV3 = new BigCommerce({
+        secret: '123456abcdef',
+        clientId: '123456abcdef',
+        callback: 'http://foo.com',
+        accessToken: '123456',
+        storeHash: '12abc',
+        apiVersion: 'v3'
+      });
+
+      bcV3.request('get', '/themes', null, function() {
         requestStub.restore();
         done();
       });


### PR DESCRIPTION
This commit adds an extra configuration parameter called `apiVersion`
that is used for specifying which version of the BigCommerce API to use
for requests.

Also updated travis configuration and removed deprecated Node versions.

Related to #33.