### PR TITLE
Authentication vulnerable to timing attack

### DIFF
--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -52,12 +52,12 @@ class BigCommerce {
 
     logger('Expected Signature: ' + expected);
 
-    if (expected === signature) {
-      logger('Signature is valid');
-      return data;
+    if (expected.length !== signature.length || !crypto.timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(signature, 'utf8'))) {
+      throw new Error('Signature is invalid');
     }
 
-    throw new Error('Signature is invalid');
+    logger('Signature is valid');
+    return data;
   }
 
   authorize(query) {

--- a/test/bigcommerce.js
+++ b/test/bigcommerce.js
@@ -68,6 +68,19 @@ describe('BigCommerce', () => {
     context('given an invalid signature', () => {
       it('should return null', () => {
         try {
+          bc.verify('eyJmb28iOiJmb28ifQ==.YjMzMTQ2ZGU4ZTUzNWJiOTI3NTI1ODJmNzhiZGM5NzBjNGQ3MjZkZDdkMDY1MjdkZGYxZDA0NGZjNDVjYmNkMQ==');
+        } catch (e) {
+          e.message.should.match(/invalid/);
+          return;
+        }
+
+        throw new Error('You shall not pass!');
+      });
+    });
+
+    context('given an invalid signature (different length)', () => {
+      it('should return null', () => {
+        try {
           bc.verify('eyJmb28iOiJmb28ifQ==.Zm9v');
         } catch (e) {
           e.message.should.match(/invalid/);


### PR DESCRIPTION
I can see the code uses strict equality to check the hashes. Probably should use `crypto.timingSafeEqual`? (but first convert the strings to buffers)