### PR TITLE
Bump version, update yarn.lock, change to async/await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '6'
 - '8'
+- '10'
 deploy:
   provider: npm
   email:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+4.0.0
+=====
+- [breaking] Updated to `async/await`
+- [breaking] Removed body from error text, added as property in error (#62)
+- [breaking] Added gzip support (#60)
+
 3.0.0
 =====
 

--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -24,23 +24,32 @@ const logger = require('debug')('node-bigcommerce:bigcommerce'),
 
 class BigCommerce {
   constructor(config) {
-    if (!config) throw new Error('Config missing. The config object is required to make any call to the BigCommerce API');
+    if (!config) {
+      throw new Error(
+        'Config missing. The config object is required to make any call to the ' +
+        'BigCommerce API'
+      );
+    }
 
     this.config = config;
     this.apiVersion = this.config.apiVersion || 'v2';
   }
 
   verify(signedRequest) {
-    if (!signedRequest) throw new Error('The signed request is required to verify the call.');
-
-    const splitRequest = signedRequest.split('.');
-
-    if (splitRequest.length < 2) {
-      throw new Error('The signed request will come in two parts seperated by a .(full stop). this signed request contains less than 2 parts.');
+    if (!signedRequest) {
+      throw new Error('The signed request is required to verify the call.');
     }
 
-    const signature = new Buffer(splitRequest[1], 'base64').toString('utf8');
-    const json = new Buffer(splitRequest[0], 'base64').toString('utf8');
+    const splitRequest = signedRequest.split('.');
+    if (splitRequest.length < 2) {
+      throw new Error(
+        'The signed request will come in two parts seperated by a .(full stop). ' +
+        'this signed request contains less than 2 parts.'
+      );
+    }
+
+    const signature = Buffer.from(splitRequest[1], 'base64').toString('utf8');
+    const json = Buffer.from(splitRequest[0], 'base64').toString('utf8');
     const data = JSON.parse(json);
 
     logger('JSON: ' + json);
@@ -52,7 +61,10 @@ class BigCommerce {
 
     logger('Expected Signature: ' + expected);
 
-    if (expected.length !== signature.length || !crypto.timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(signature, 'utf8'))) {
+    if (
+      expected.length !== signature.length ||
+      !crypto.timingSafeEqual(Buffer.from(expected, 'utf8'), Buffer.from(signature, 'utf8'))
+    ) {
       throw new Error('Signature is invalid');
     }
 
@@ -60,8 +72,8 @@ class BigCommerce {
     return data;
   }
 
-  authorize(query) {
-    if (!query) return Promise.reject(new Error('The URL query paramaters are required.'));
+  async authorize(query) {
+    if (!query) throw new Error('The URL query paramaters are required.');
 
     const payload = {
       client_id: this.config.clientId,
@@ -73,8 +85,11 @@ class BigCommerce {
       context: query.context
     };
 
-    const request = new Request('login.bigcommerce.com', { failOnLimitReached: this.config.failOnLimitReached });
-    return request.run('post', '/oauth2/token', payload);
+    const request = new Request('login.bigcommerce.com', {
+      failOnLimitReached: this.config.failOnLimitReached
+    });
+
+    return await request.run('post', '/oauth2/token', payload);
   }
 
   createAPIRequest() {
@@ -91,15 +106,19 @@ class BigCommerce {
     });
   }
 
-  request(type, path, data) {
+  async request(type, path, data) {
     if (!this.config.accessToken || !this.config.storeHash) {
-      return Promise.reject(new Error('Get request error: the access token and store hash are required to call the BigCommerce API'));
+      throw new Error(
+        'Get request error: the access token and store hash are required to ' +
+        'call the BigCommerce API'
+      );
     }
 
     const extension = this.config.responseType === 'xml' ? '.xml' : '';
     const version = this.apiVersion;
 
     const request = this.createAPIRequest();
+
     let fullPath = `/stores/${this.config.storeHash}/${version}`;
     if (version !== 'v3') {
       fullPath += path.replace(/(\?|$)/, extension + '$1');
@@ -107,23 +126,23 @@ class BigCommerce {
       fullPath += path;
     }
 
-    return request.run(type, fullPath, data);
+    return await request.run(type, fullPath, data);
   }
 
-  get(path) {
-    return this.request('get', path);
+  async get(path) {
+    return await this.request('get', path);
   }
 
-  post(path, data) {
-    return this.request('post', path, data);
+  async post(path, data) {
+    return await this.request('post', path, data);
   }
 
-  put(path, data) {
-    return this.request('put', path, data);
+  async put(path, data) {
+    return await this.request('put', path, data);
   }
 
-  delete(path) {
-    return this.request('delete', path);
+  async delete(path) {
+    return await this.request('delete', path);
   }
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,7 +8,7 @@ const logger = require('debug')('node-bigcommerce:request'),
   https = require('https'),
   zlib = require('zlib');
 
-const version = require('../package.json').version;
+const { version } = require('../package.json');
 
 /**
  * Parse response
@@ -64,7 +64,7 @@ class Request {
     if (this.agent) options.agent = this.agent;
 
     if (data) {
-      options.headers['Content-Length'] = new Buffer(dataString).length;
+      options.headers['Content-Length'] = Buffer.from(dataString).length;
     }
 
     logger('Starting Request, with options.', options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-bigcommerce",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "A node module for authentication and use with the BigCommerce API",
   "main": "./lib/bigcommerce",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,6 +101,11 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 async@1.x, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -149,13 +154,25 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-"chai@>=1.9.2 <4.0.0", chai@^3.5.0:
+chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"
   dependencies:
     assertion-error "^1.0.1"
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
+
+chai@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.2.0.tgz#760aa72cf20e3795e84b12877ce0e83737aa29e5"
+  integrity sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^3.0.1"
+    get-func-name "^2.0.0"
+    pathval "^1.1.0"
+    type-detect "^4.0.5"
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -174,6 +191,11 @@ chalk@^2.0.0, chalk@^2.1.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -253,7 +275,7 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@^2.2.0, debug@^2.6.8:
+debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -265,6 +287,13 @@ debug@^3.0.1, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -274,6 +303,13 @@ deep-eql@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
   dependencies:
     type-detect "0.1.1"
+
+deep-eql@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  integrity sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-equal@^1.0.0:
   version "1.0.1"
@@ -535,6 +571,11 @@ function-bind@^1.0.2:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
 glob@3.2.11:
   version "3.2.11"
@@ -821,13 +862,14 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
 lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.5:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 lolex@1.3.2:
   version "1.3.2"
@@ -906,6 +948,11 @@ ms@2.0.0, ms@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -914,18 +961,20 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-nock@^7.0.2:
-  version "7.7.3"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-7.7.3.tgz#d0600980a4443edf6e50b5ed3314602cb7ccc489"
+nock@^10.0.1:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-10.0.2.tgz#9e9a92253808e480a8163c2a21fc12937c02c3b0"
+  integrity sha512-uWrdlRzG28SXM5yqYsUHfYBRqljF8P6aTRDh6Y5kTgs/Q4GB59QWlpiegmDHQouvmX/rDyKkC/nk+k4nA+QPNw==
   dependencies:
-    chai ">=1.9.2 <4.0.0"
-    debug "^2.2.0"
+    chai "^4.1.2"
+    debug "^4.1.0"
     deep-equal "^1.0.0"
     json-stringify-safe "^5.0.1"
-    lodash "^3.10.1"
+    lodash "^4.17.5"
     mkdirp "^0.5.0"
-    propagate "0.3.x"
-    qs "^6.0.2"
+    propagate "^1.0.0"
+    qs "^6.5.1"
+    semver "^5.5.0"
 
 nopt@3.x:
   version "3.0.6"
@@ -1024,6 +1073,11 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+pathval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+  integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -1060,17 +1114,19 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
-propagate@0.3.x:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.3.1.tgz#e3a84404a7ece820dd6bbea9f6d924e3135ae09c"
+propagate@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-1.0.0.tgz#00c2daeedda20e87e3782b344adba1cddd6ad709"
+  integrity sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=
 
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-qs@^6.0.2:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
+qs@^6.5.1:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
+  integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -1174,6 +1230,11 @@ samsam@~1.1:
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
+semver@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
+  integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -1345,6 +1406,11 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
No node 6 support, adds node 10 to test suite. Also removes deprecated `new Buffer()` call.

**After merge:**
* Tag & publish