### PR TITLE
Add support for JWT-based callbacks

### DIFF
--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const jwt = require('jsonwebtoken');
+const isIp = require('is-ip');
 
 /**
  * BigCommerce OAuth2 Authentication and API access
@@ -107,6 +108,51 @@ class BigCommerce {
     }, this.config.secret, { expiresIn: '24h', algorithm: 'HS256' });
   }
 
+  /** Construct a JWT for customer login https://developer.bigcommerce.com/api-docs/storefront/customer-login-api
+   * @param customerId
+   * @param channelId
+   * @param options
+   * @returns string
+   */
+  createCustomerLoginJWT(customerId, channelId = 1, options = {}) {
+    const payload = {
+      iss: this.config.clientId,
+      operation: 'customer_login',
+      store_hash: this.config.storeHash,
+      customer_id: customerId,
+      channel_id: channelId,
+      jti: crypto.randomBytes(32).toString('hex')
+    };
+
+    /* Optional redirect URL (relative path on the storefront), e.g. '/shop-all/' */
+    if (options.redirectUrl) {
+      payload.redirect_url = options.redirectUrl;
+    }
+
+    /*
+    * Optional end-user IP for extra security
+    * The login will be rejected if it does not come from this IP
+    */
+    if (options.requestIP) {
+      if (!isIp(options.requestIP)) {
+        throw new Error('Invalid IP address');
+      }
+      payload.request_ip = options.requestIP;
+    }
+
+    /*
+     * Run an API request to get the current server time from BC to use for the JWT generation
+     * This is useful to prevent clock skew resulting in invalid JWTs
+     */
+    if (options.useBCTime) {
+      payload.iat = this.getTime();
+    } else {
+      payload.iat = Math.floor(Date.now() / 1000);
+    }
+
+    return jwt.sign(payload, this.config.secret, { expiresIn: '24h', algorithm: 'HS256' });
+  }
+
   async authorize(query) {
     if (!query) throw new Error('The URL query paramaters are required.');
 
@@ -162,6 +208,12 @@ class BigCommerce {
     }
 
     return await request.run(type, fullPath, data);
+  }
+
+  getTime() {
+    const request = this.createAPIRequest();
+
+    return request.run('GET', `/stores/${this.config.storeHash}/v2/time`).time;
   }
 
   async get(path) {

--- a/lib/bigcommerce.js
+++ b/lib/bigcommerce.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const jwt = require('jsonwebtoken');
+
 /**
  * BigCommerce OAuth2 Authentication and API access
  *
@@ -36,6 +38,7 @@ class BigCommerce {
     this.apiVersion = this.config.apiVersion || 'v2';
   }
 
+  /** Verify legacy signed_payload (can be ignored in favor of JWT) **/
   verify(signedRequest) {
     if (!signedRequest) {
       throw new Error('The signed request is required to verify the call.');
@@ -71,6 +74,37 @@ class BigCommerce {
 
     logger('Signature is valid');
     return data;
+  }
+
+  /** Verify signed_payload_jwt from load callback or constructed from constructJwtFromAuthData
+   * @param signedRequestJwt
+   * @returns object
+   */
+  verifyJWT(signedRequestJwt) {
+    return jwt.verify(signedRequestJwt, this.config.secret, {
+      algorithms: ['HS256'],
+      audience: this.config.client_id
+    });
+  }
+
+  /** Construct a JWT mimicking the format of the load callback from the auth callback data
+   * to use in an app
+   * (to minimize duplication of code related to handling callbacks)
+   * callbacks
+   * @param user
+   * @param context
+   * @param url
+   * @returns string
+   */
+  constructJWTFromAuthData(user, context, url) {
+    return jwt.sign({
+      aud: this.config.client_id,
+      iss: this.config.client_id,
+      sub: context,
+      user,
+      owner: user,
+      url: url || '/'
+    }, this.config.secret, { expiresIn: '24h', algorithm: 'HS256' });
   }
 
   async authorize(query) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "supervisor": "^0.12.0"
   },
   "dependencies": {
-    "debug": "^3.1.0"
+    "debug": "^3.1.0",
+    "jsonwebtoken": "^8.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
+    "is-ip": "^3.1.0",
     "jsonwebtoken": "^8.5.1"
   }
 }

--- a/test/bigcommerce.js
+++ b/test/bigcommerce.js
@@ -100,6 +100,66 @@ describe('BigCommerce', () => {
     });
   });
 
+  describe('#verifyJWT', () => {
+    context('given a null JWT', () => {
+      it('should return error', () => {
+        try {
+          bc.verifyJWT();
+        } catch (e) {
+          e.message.should.match(/jwt must be provided/);
+          return;
+        }
+
+        throw new Error('You shall not pass!');
+      });
+    });
+
+    context('given an invalid signature', () => {
+      it('should return an error', () => {
+        try {
+          bc.verifyJWT('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIxMjM0NTZhYmNkZWYiLCJpc3MiOiJiYyIsImlhdCI6MTYyMjc0MjcyNywibmJmIjoxNjIyNzQyNzIyLCJleHAiOjMxMjI4MjkxMjcsImp0aSI6ImY0NGI1NmU5LTI1ZTUtNDQ3OC05ODUyLTQwMjdlNzMyYmY0OSIsInN1YiI6InN0b3Jlcy8xMmFiYyIsInVzZXIiOnsiaWQiOjIzNjksImVtYWlsIjoidGVzdEB0ZXN0LnRlc3QifSwib3duZXIiOnsiaWQiOjIzNjksImVtYWlsIjoidGVzdEB0ZXN0LnRlc3QifSwidXJsIjoiLyJ9.61QXFp-vG9yN7KK9M56PMOdv5lWAFt4u4jv8C8slSqA');
+        } catch (e) {
+          e.message.should.match(/invalid/);
+          return;
+        }
+
+        throw new Error('You shall not pass!');
+      });
+    });
+
+    it('should return the JSON data', () => {
+      const verify = bc.verifyJWT(
+        'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIxMjM0NTZhYmNkZWYiLCJpc3MiOiJiYyIsImlhdCI6MTYyMjc0MjcyNywibmJmIjoxNjIyNzQyNzIyLCJleHAiOjM2MjI4MjkxMjcsImp0aSI6ImY0NGI1NmU5LTI1ZTUtNDQ3OC05ODUyLTQwMjdlNzMyYmY0OSIsInN1YiI6InN0b3Jlcy8xMmFiYyIsInVzZXIiOnsiaWQiOjIzNjksImVtYWlsIjoidGVzdEB0ZXN0LnRlc3QifSwib3duZXIiOnsiaWQiOjIzNjksImVtYWlsIjoidGVzdEB0ZXN0LnRlc3QifSwidXJsIjoiLyJ9.QRTvS1SVBEPrnBb2woA16sbFvNjb8b0vzwF17sVNYV4',
+        bc.config.client_secret
+      );
+      verify.sub.should.equal('stores/12abc');
+    });
+  });
+
+  describe('#constructJWTFromAuthData', () => {
+    context('given auth callback data', () => {
+      it('should return a valid jwt', () => {
+        const authServiceResponse = {
+          access_token: 'ACCESS_TOKEN',
+          scope: 'store_v2_orders',
+          user: {
+            id: 24654,
+            email: 'merchant@mybigcommerce.com'
+          },
+          context: 'stores/12abc'
+        };
+        const verify = bc.verifyJWT(
+          bc.constructJWTFromAuthData(
+            authServiceResponse.user,
+            authServiceResponse.context,
+            '/',
+          )
+        );
+        verify.sub.should.equal('stores/12abc');
+      });
+    });
+  });
+
   describe('#authorize', () => {
     beforeEach(() => {
       self.runStub = self.sandbox.stub(Request.prototype, 'run')

--- a/test/bigcommerce.js
+++ b/test/bigcommerce.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const jwt = require('jsonwebtoken');
+
 const BigCommerce = require('../lib/bigcommerce'),
   Request = require('../lib/request'),
   should = require('chai').should(),
@@ -156,6 +158,23 @@ describe('BigCommerce', () => {
           )
         );
         verify.sub.should.equal('stores/12abc');
+      });
+    });
+  });
+
+  describe('#createCustomerLoginJWT', () => {
+    context('given a customer ID and channel ID', () => {
+      it('should return a valid jwt', () => {
+        const loginJWT = bc.createCustomerLoginJWT(1);
+        Math.floor(jwt.verify(loginJWT, bc.config.secret).iat - Math.floor(Date.now() / 1000))
+          .should.equal(0);
+        jwt.verify(loginJWT, bc.config.secret).store_hash.should.equal('12abc');
+        // We've already verified, so now just decode
+        jwt.decode(loginJWT).customer_id.should.equal(1);
+        jwt.decode(loginJWT).channel_id.should.equal(1);
+        jwt.decode(loginJWT).operation.should.equal('customer_login');
+        jwt.decode(loginJWT).iss.should.equal(bc.config.clientId);
+        jwt.decode(loginJWT).jti.length.should.be.above(20);
       });
     });
   });


### PR DESCRIPTION
Add a few new methods for JWT-based features on BC:

- `verifyJWT` which helps decode the `signed_payload_jwt` now passed on load callbacks for apps

JWT-based callbacks should be easier to use for consumers going forward, and we are likely to extend this callback with more data in the future

- `constructJwtFromAuthData` which constructs as JWT similar to the one you would get from the load callback, but using the data from the auth callback. This allows you to use JWT-based session management in a consistent way regardless of how the app is loaded.

- `createCustomerLoginJWT` to help with creation of JWT for the [customer login API](https://developer.bigcommerce.com/api-docs/storefront/customer-login-api)
- `getTime` supporting method to get system time, useful for customer login API