### PR TITLE
Add fallback x-retry-after for /v3/validate-credentials

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -83,7 +83,7 @@ class Request {
 
         // If the API limit has been reached
         if (res.statusCode === 429) {
-          const timeToWait = res.headers['x-retry-after'];
+          const timeToWait = res.headers['x-retry-after'] || 3;
 
           if (this.failOnLimitReached) {
             const err = new Error(`You have reached the rate limit for the BigCommerce API. Please retry in ${timeToWait} seconds.`);


### PR DESCRIPTION
/v3/validate-credentials can return 429 but never returns x-retry-after header (only /v3/validate-credentials does this)

This makes timeToWait here: https://github.com/getconversio/node-bigcommerce/blob/40b9fb2d948ff0fa2f19d31fbf872754fb6cfe35/lib/request.js#L103
equal to `undefined`.

undefined*1000 equals NaN

`setTimeout(() => {console.log('hello')}, NaN)` executes immediately

My fix is as follows:
If there is a 429 response that doesn't contain the x-retry-after header, add a fallback value of 3s. This should at least make the 429 retries not immediate